### PR TITLE
support HTTP/1.1 in response code parsing

### DIFF
--- a/httpclient.c
+++ b/httpclient.c
@@ -322,6 +322,9 @@ int http_get_simple(char *server_and_port, char *auth_token,
 	if (sscanf(line,"HTTP/1.0 %d",&http_response)==1) {
 	  // got http response
 	}
+	if (sscanf(line,"HTTP/1.1 %d",&http_response)==1) {
+	  // got http response
+	}
 	len=0;
 	// Have we found end of headers?
 	if (empty_count==3) break;


### PR DESCRIPTION
Current servald versions answer using HTTP/1.1.. lbard expects a HTTP/1.0 response thus never parsing the response code and returns -1.